### PR TITLE
Cleanups

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^models$
 ^codecov\.yml$
 ^\.Renviron$
+^vignettes$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,19 +33,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()

--- a/.github/workflows/pkgdown-pak.yaml
+++ b/.github/workflows/pkgdown-pak.yaml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: pkgdown
           needs: website

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     hardhat (>= 0.1.0),
     janitor (>= 1.0.0),
     magrittr (>= 1.0.0),
-    nflreadr (>= 1.1.3),
+    nflreadr (>= 1.3.0),
     purrr (>= 0.3.0),
     rappdirs (>= 0.3.0),
     recipes (>= 0.1.16),

--- a/R/ep_build.R
+++ b/R/ep_build.R
@@ -17,7 +17,7 @@
 #' @family main
 #'
 #' @export
-ep_build <- function(season = nflreadr:::most_recent_season(), version = "latest"){
+ep_build <- function(season = nflreadr::most_recent_season(), version = "latest"){
 
   version <- rlang::arg_match0(version, c("latest", "v1.0.0"))
 

--- a/R/ep_load.R
+++ b/R/ep_load.R
@@ -21,7 +21,7 @@
 #' @family main
 #'
 #' @export
-ep_load <- function(season = nflreadr:::most_recent_season(),
+ep_load <- function(season = nflreadr::most_recent_season(),
                     type = c("weekly","pbp_pass","pbp_rush"),
                     version = c("latest","v1.0.0")){
 

--- a/ffopportunity.Rproj
+++ b/ffopportunity.Rproj
@@ -20,3 +20,5 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
+
+UseNativePipeOperator: No

--- a/man/ep_build.Rd
+++ b/man/ep_build.Rd
@@ -4,7 +4,7 @@
 \alias{ep_build}
 \title{Build EP}
 \usage{
-ep_build(season = nflreadr:::most_recent_season(), version = "latest")
+ep_build(season = nflreadr::most_recent_season(), version = "latest")
 }
 \arguments{
 \item{season}{a numeric vector of seasons that defaults to most recent season. Must be later than 2006.}

--- a/man/ep_load.Rd
+++ b/man/ep_load.Rd
@@ -5,7 +5,7 @@
 \title{Load Expected Points data}
 \usage{
 ep_load(
-  season = nflreadr:::most_recent_season(),
+  season = nflreadr::most_recent_season(),
   type = c("weekly", "pbp_pass", "pbp_rush"),
   version = c("latest", "v1.0.0")
 )

--- a/tests/testthat/test-ep_build.R
+++ b/tests/testthat/test-ep_build.R
@@ -13,5 +13,4 @@ test_that("ep_build and ep_load work", {
   expect_equal(nrow(ep_2020$ep_weekly), nrow(ep_weekly))
   expect_equal(nrow(ep_2020$ep_pbp_pass), nrow(ep_pbp_pass))
   expect_equal(nrow(ep_2020$ep_pbp_rush), nrow(ep_pbp_rush))
-
 })

--- a/update/ep_update.R
+++ b/update/ep_update.R
@@ -38,11 +38,15 @@ update_ep <- function(season, version = "v1.0.0", folder_path){
   upload_ep_data(folder_path, version)
   invisible(NULL)
 }
+
+version <- "v1.0.0"
+temp <- tempdir(check = TRUE)
+
 try(piggyback::pb_new_release(repo = "ffverse/ffopportunity", tag = "latest-data"))
 try(piggyback::pb_new_release(repo = "ffverse/ffopportunity", tag = glue::glue("{version}-data")))
-temp <- tempdir()
-update_ep(nflreadr:::most_recent_season(), version = "latest", folder_path = temp)
-update_ep(nflreadr:::most_recent_season(), version = "v1.0.0", folder_path = temp)
+
+update_ep(nflreadr::most_recent_season(), version = "latest", folder_path = temp)
+update_ep(nflreadr::most_recent_season(), version = "v1.0.0", folder_path = temp)
 
 unlink(temp, recursive = TRUE, force = TRUE)
 


### PR DESCRIPTION
- [x] ignore vignettes - skipping for purposes of CRAN release
- [x] rebuild 2020 EP so that tests pass
- [x] depend on nflreadr v1.3.0, closes #6 
- [x] use r-lib/actions@v2 
- [x] switch `nflreadr:::most_recent_season` to `nflreadr::most_recent_season`
- [x] ensure magrittr pipe is default 
- [x] cleanup deps
