### PR TITLE
Issue #17:  Add pass* to all total* sum

### DIFF
--- a/R/ep_summarize.R
+++ b/R/ep_summarize.R
@@ -175,7 +175,21 @@ ep_summarize <- function(predicted_pbp, stat_type = c("all", "expected_points", 
     combined_df %>%
     dplyr::group_by(.data$season, .data$posteam, .data$week, .data$game_id) %>%
     dplyr::summarise(
-      dplyr::across(.cols = where(is.numeric), .fns = sum, .names = "{col}_team")
+      dplyr::across(.cols = where(is.numeric) & !contains("total"), .fns = sum, .names = "{col}_team"),
+      total_yards_gained_team = .data$rec_yards_gained_team + .data$rush_yards_gained_team,
+      total_yards_gained_exp_team = .data$rec_yards_gained_exp_team + .data$rush_yards_gained_exp_team,
+      total_yards_gained_diff_team = .data$rec_yards_gained_diff_team + .data$rush_yards_gained_diff_team,
+
+      total_touchdown_team = .data$rec_touchdown_team + .data$rush_touchdown_team,
+      total_touchdown_exp_team = .data$rec_touchdown_exp_team + .data$rush_touchdown_exp_team,
+      total_touchdown_diff_team = .data$rec_touchdown_diff_team + .data$rush_touchdown_diff_team,
+
+      total_first_down_team = .data$rec_first_down_team + .data$rush_first_down_team,
+      total_first_down_exp_team = .data$rec_first_down_exp_team + .data$rush_first_down_exp_team,
+      total_first_down_diff_team = .data$rec_first_down_diff_team + .data$rush_first_down_diff_team,
+      total_fantasy_points_team = .data$rec_fantasy_points_team + .data$rush_fantasy_points_team,
+      total_fantasy_points_exp_team = .data$rec_fantasy_points_exp_team + .data$rush_fantasy_points_exp_team,
+      total_fantasy_points_diff_team = .data$rec_fantasy_points_diff_team + .data$rush_fantasy_points_diff_team
     ) %>%
     dplyr::ungroup()
 

--- a/R/ep_summarize.R
+++ b/R/ep_summarize.R
@@ -142,14 +142,14 @@ ep_summarize <- function(predicted_pbp, stat_type = c("all", "expected_points", 
     janitor::remove_empty(which = "cols") %>%
     dplyr::mutate(dplyr::across(.cols = where(is.numeric), .fns =  ~tidyr::replace_na(.x, 0) %>% round(2))) %>%
     dplyr::mutate(
-      total_yards_gained = .data$rec_yards_gained + .data$rush_yards_gained,
-      total_yards_gained_exp = .data$rec_yards_gained_exp + .data$rush_yards_gained_exp,
-      total_touchdown = .data$rec_touchdown + .data$rush_touchdown,
-      total_touchdown_exp = .data$rec_touchdown_exp + .data$rush_touchdown_exp,
-      total_first_down = .data$rec_first_down + .data$rush_first_down,
-      total_first_down_exp = .data$rec_first_down_exp + .data$rush_first_down_exp,
-      total_fantasy_points = .data$rec_fantasy_points + .data$rush_fantasy_points,
-      total_fantasy_points_exp = .data$rec_fantasy_points_exp + .data$rush_fantasy_points_exp) %>%
+      total_yards_gained = .data$rec_yards_gained + .data$rush_yards_gained + .data$pass_yards_gained,
+      total_yards_gained_exp = .data$rec_yards_gained_exp + .data$rush_yards_gained_exp + .data$pass_yards_gained_exp,
+      total_touchdown = .data$rec_touchdown + .data$rush_touchdown + .data$pass_touchdown,
+      total_touchdown_exp = .data$rec_touchdown_exp + .data$rush_touchdown_exp + .data$pass_touchdown_exp,
+      total_first_down = .data$rec_first_down + .data$rush_first_down + .data$pass_first_down,
+      total_first_down_exp = .data$rec_first_down_exp + .data$rush_first_down_exp + .data$pass_first_down_exp,
+      total_fantasy_points = .data$rec_fantasy_points + .data$rush_fantasy_points + .data$pass_fantasy_points,
+      total_fantasy_points_exp = .data$rec_fantasy_points_exp + .data$rush_fantasy_points_exp + .data$pass_fantasy_points_exp) %>%
     dplyr::ungroup() %>%
     dplyr::rename(
       pass_completions = .data$pass_complete_pass,


### PR DESCRIPTION
Referenced in Issue #17. 

Fixing bug in all `total*` sums where contributions from the passing game are omitted.